### PR TITLE
Fix GCC 14 compat, entropy starvation, image packaging, and login

### DIFF
--- a/board/sharp/brain_imx28/post-build.sh
+++ b/board/sharp/brain_imx28/post-build.sh
@@ -8,6 +8,19 @@ append_inittab()
 	patch --forward -r - -p 0 < board/sharp/brain_imx28/inittab.patch || true
 }
 
+
+install_securetty()
+{
+	# BusyBox is compiled with CONFIG_FEATURE_SECURETTY=y.  Without /etc/securetty
+	# root login is silently denied on every terminal.  Create the file listing
+	# the consoles used on SHARP Brain devices.
+        cat > "${TARGET_DIR}/etc/securetty" <<'EOF'
+console
+tty1
+ttyAMA0
+EOF
+}
+
 promote_haveged_initscript()
 {
 	# haveged initializes at S21 by default. Move it to S10 so it starts before
@@ -18,6 +31,7 @@ promote_haveged_initscript()
 main()
 {
 	append_inittab
+	install_securetty
 	promote_haveged_initscript
 	exit $?
 }

--- a/board/sharp/brain_imx28/post-build.sh
+++ b/board/sharp/brain_imx28/post-build.sh
@@ -8,9 +8,17 @@ append_inittab()
 	patch --forward -r - -p 0 < board/sharp/brain_imx28/inittab.patch || true
 }
 
+promote_haveged_initscript()
+{
+	# haveged initializes at S21 by default. Move it to S10 so it starts before
+	# S20seedrng, which blocks on getrandom(2) until the CRNG is seeded.
+	mv "${TARGET_DIR}/etc/init.d/S21haveged" "${TARGET_DIR}/etc/init.d/S10haveged"
+}
+
 main()
 {
 	append_inittab
+	promote_haveged_initscript
 	exit $?
 }
 

--- a/board/sharp/brain_imx28/post-build.sh
+++ b/board/sharp/brain_imx28/post-build.sh
@@ -2,6 +2,9 @@
 
 append_inittab()
 {
+	if grep -q '^tty1::respawn:' "${TARGET_DIR}/etc/inittab"; then
+		return 0
+	fi
 	# --forward: don't reverse-apply
 	# -r -: discard rejected hunk
 	# -p 0: respect the entire path
@@ -25,7 +28,9 @@ promote_haveged_initscript()
 {
 	# haveged initializes at S21 by default. Move it to S10 so it starts before
 	# S20seedrng, which blocks on getrandom(2) until the CRNG is seeded.
-	mv "${TARGET_DIR}/etc/init.d/S21haveged" "${TARGET_DIR}/etc/init.d/S10haveged"
+	if [ -e "${TARGET_DIR}/etc/init.d/S21haveged" ]; then
+		mv "${TARGET_DIR}/etc/init.d/S21haveged" "${TARGET_DIR}/etc/init.d/S10haveged"
+	fi
 }
 
 main()

--- a/board/sharp/brain_imx28/post-build.sh
+++ b/board/sharp/brain_imx28/post-build.sh
@@ -5,7 +5,7 @@ append_inittab()
 	# --forward: don't reverse-apply
 	# -r -: discard rejected hunk
 	# -p 0: respect the entire path
-	patch --forward -r - -p 0 < board/sharp/brain_imx28/inittab.patch || true
+	patch --forward -r - "${TARGET_DIR}/etc/inittab" < board/sharp/brain_imx28/inittab.patch
 }
 
 

--- a/configs/brain_imx28_defconfig
+++ b/configs/brain_imx28_defconfig
@@ -10,6 +10,7 @@ BR2_TARGET_GENERIC_GETTY_PORT="ttyAMA0"
 
 # Filesystem
 BR2_TARGET_ROOTFS_CPIO=y
+BR2_TARGET_ROOTFS_TAR=y
 
 # To modify the rootfs
 BR2_ROOTFS_POST_BUILD_SCRIPT="board/sharp/brain_imx28/post-build.sh"

--- a/configs/brain_imx28_defconfig
+++ b/configs/brain_imx28_defconfig
@@ -8,6 +8,11 @@ BR2_KERNEL_HEADERS_5_4=y
 # system
 BR2_TARGET_GENERIC_GETTY_PORT="ttyAMA0"
 
+# haveged: userspace entropy daemon started early (S10, before S20seedrng) to
+# feed the kernel CRNG pool on boot.  Without it the i.MX28 has no hardware RNG
+# and crng init done is delayed ~4 minutes, blocking the login prompt.
+BR2_PACKAGE_HAVEGED=y
+
 # Filesystem
 BR2_TARGET_ROOTFS_CPIO=y
 BR2_TARGET_ROOTFS_TAR=y

--- a/support/kconfig/lxdialog/check-lxdialog.sh
+++ b/support/kconfig/lxdialog/check-lxdialog.sh
@@ -48,7 +48,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2

--- a/support/kconfig/patches/22-kconfig-lxdialog-fix-check-with-GCC14.patch
+++ b/support/kconfig/patches/22-kconfig-lxdialog-fix-check-with-GCC14.patch
@@ -1,0 +1,43 @@
+From 3ae91337b53fa3ccf0bad7f181fcaf483fab22ee Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 3 Apr 2024 14:18:07 +0200
+Subject: [PATCH] kconfig/lxdialog: fix check() with GCC14
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC14 now treats implicit int types as error so when check() from
+check-lxdialog.sh is called to check whether we can link against ncurses
+it will fail silently and the help text indicating to install ncurses is
+printed.
+
+However, this is not due to missing ncurses but once the stderr redirect
+to /dev/null is removed we can see the root cause:
+<stdin>:2:1: error: return type defaults to ‘int’ [-Wimplicit-int]
+
+So, in order for menuconfig to work with GCC14 lets just specify the
+return type of main() as int.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Reviewed-by: Petr Vorel <petr.vorel@gmail.com>
+Tested-by: Petr Vorel <petr.vorel@gmail.com>
+---
+ kconfig/lxdialog/check-lxdialog.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kconfig/lxdialog/check-lxdialog.sh b/kconfig/lxdialog/check-lxdialog.sh
+index 16cd9a3186..27d6c30a57 100755
+--- a/kconfig/lxdialog/check-lxdialog.sh
++++ b/kconfig/lxdialog/check-lxdialog.sh
+@@ -48,7 +48,7 @@ trap "rm -f $tmp" 0 1 2 3 15
+ check() {
+         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
+ #include CURSES_LOC
+-main() {}
++int main() {}
+ EOF
+ 	if [ $? != 0 ]; then
+ 	    echo " *** Unable to find the ncurses libraries or the"       1>&2
+-- 
+2.44.0
+

--- a/support/kconfig/patches/series
+++ b/support/kconfig/patches/series
@@ -10,3 +10,4 @@
 19-merge_config.sh-add-br2-external-support.patch
 20-merge_config.sh-Allow-to-define-config-prefix.patch
 21-Avoid-false-positive-matches-from-comment-lines.patch
+22-kconfig-lxdialog-fix-check-with-GCC14.patch


### PR DESCRIPTION
Five fixes for the SHARP Brain i.MX28 Buildroot target:

**1. `kconfig/lxdialog: fix check() with GCC14`**

Cherry-picked from upstream buildroot commit [`a6210d28`](https://gitlab.com/buildroot.org/buildroot/-/commit/a6210d28dbf66b2f0a42d945711dfd93c7329feb). GCC 14 (Debian trixie) promoted `-Wimplicit-int` to a hard error, causing `make menuconfig` to abort. Fix: `main() {}` → `int main() {}`.

**2. `configs: brain_imx28: enable BR2_TARGET_ROOTFS_TAR`**

Adds `BR2_TARGET_ROOTFS_TAR=y` so Buildroot produces `output/images/rootfs.tar`, which the `buildbrain` orchestration scripts need to extract the rootfs onto the SD image.

**3. `configs: brain_imx28: enable haveged for early entropy on boot`**

The i.MX28 has no hardware RNG. Without a userspace entropy source, `S20seedrng` calls `getrandom(2)` without `GRND_NONBLOCK` and blocks ~4 minutes until `crng init done`, which holds up all BusyBox init `sysinit` entries and delays the login prompt by the same amount. Enable `BR2_PACKAGE_HAVEGED=y` so haveged can be started early (via a `buildbrain` overlay script) before `S20seedrng`.

**4. `board/sharp/brain_imx28: fix append_inittab to use TARGET_DIR`**

U-Boot passes `console=ttyAMA0,115200 console=tty1` in bootargs. With multiple `console=` entries the kernel assigns `/dev/console` to the last one, so `/dev/console` is `tty1` (LCD framebuffer), not the serial port. The original inittab patch only added a `ttyAMA0` getty, which is invisible on the LCD. Replace with:
- `tty1::respawn:/sbin/getty -L tty1 0 vt100` (LCD, primary)
- `ttyAMA0::respawn:/sbin/getty -L ttyAMA0 115200 vt100` (serial)

The patch command used `-p0` with a hardcoded `output/target/` path in the patch header.  When Buildroot is invoked with `O=` pointing elsewhere (as the Docker-based build in https://github.com/brain-hackers/buildbrain/pull/61 does with `O=/work/buildroot_output`), the file is
not found and the patch is silently skipped due to '|| true'.

Fix: pass `${TARGET_DIR}/etc/inittab` explicitly on the command line. `patch(1)` ignores the header paths when a target file is given directly, so this works regardless of the `O=` setting.

Also remove `|| true` so that it will fail loudly when it fails to patch `inittab`, which is critical for making the TTY log-in-able, so it should not be failing silently.

**5. `board/sharp/brain_imx28: create /etc/securetty in post-build`**

BusyBox is compiled with `CONFIG_FEATURE_SECURETTY=y` (both in this repo and upstream Buildroot). When that feature is enabled and `/etc/securetty` is absent, BusyBox `login` silently denies root on every terminal — the `login:` prompt simply repeats with no error. The upstream Buildroot skeleton does not ship `/etc/securetty`. Add `install_securetty()` to `post-build.sh` to create the file listing `console`, `tty1`, and `ttyAMA0`.